### PR TITLE
Fix DashTrail bug + Phantom hitbox

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -13765,6 +13765,22 @@ MonoBehaviour:
   src: 0.25
   dest: 0.5
   reverse: 0
+--- !u!114 &1392825370 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3886620743913105595, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
+  m_PrefabInstance: {fileID: 3788763494468674283}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ddf4d5f1dd73d30d87e7f03d79b3879, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!58 &1392825371 stripped
+CircleCollider2D:
+  m_CorrespondingSourceObject: {fileID: 7021266429385059215, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
+  m_PrefabInstance: {fileID: 3788763494468674283}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1398079826
 GameObject:
   m_ObjectHideFlags: 0
@@ -14590,6 +14606,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1564216659771814530, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
     - target: {fileID: 3788763495853368516, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
       propertyPath: m_RootOrder
       value: 5
@@ -14639,6 +14659,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1446569597}
     - target: {fileID: 3788763495853368518, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
+      propertyPath: callback
+      value: 
+      objectReference: {fileID: 1392825370}
+    - target: {fileID: 3788763495853368518, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
       propertyPath: maxAngle
       value: 45
       objectReference: {fileID: 0}
@@ -14648,12 +14672,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3788763495853368519, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
       propertyPath: m_TagString
-      value: Player
+      value: Untagged
       objectReference: {fileID: 0}
     - target: {fileID: 3886620743913105595, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
       propertyPath: source
       value: 
       objectReference: {fileID: 1446569597}
+    - target: {fileID: 3886620743913105595, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
+      propertyPath: collider
+      value: 
+      objectReference: {fileID: 1392825371}
+    - target: {fileID: 3886620743913105595, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
+      propertyPath: tagToIgnore
+      value: Player
+      objectReference: {fileID: 0}
     - target: {fileID: 3886620743913105595, guid: 52917d9f49574d94eaf02a9575e364f3, type: 3}
       propertyPath: knockbackStrength
       value: 50

--- a/Assets/Scripts/AttackTriggerCallback.cs
+++ b/Assets/Scripts/AttackTriggerCallback.cs
@@ -16,10 +16,30 @@ public class AttackTriggerCallback : MonoBehaviour
     [SerializeField]
     private int damage = 20;
 
+    [SerializeField]
+    private Collider2D collider = null;
+
+    [SerializeField]
+    private string tagToIgnore = "";
+
+
+    private void Start() 
+    {
+        collider.enabled = false;
+    }
+
+    public void EnableHitbox() {
+        collider.enabled = true;
+    }
+
+    public void DisableHitbox() {
+        collider.enabled = false;
+    }
+
     private void OnTriggerEnter2D(Collider2D other)
     {
         // This check is needed so Attacker doesn't hurt themselves
-        if(other.tag != this.tag) {
+        if(other.tag != tagToIgnore) {
             // Turn off MobController, otherwise force will do nothing
             MobController controller = other.GetComponent<MobController>();
             controller.UnPlugFor(knockbackDuration);

--- a/Assets/Scripts/Dash.cs
+++ b/Assets/Scripts/Dash.cs
@@ -13,6 +13,12 @@ public class Dash : MonoBehaviour
     [SerializeField] private MobController mobController = null;
     [SerializeField] private TrailRenderer trailRenderer = null;
 
+    private void Start() 
+    {
+        trailRenderer.emitting = false;
+
+    }
+
     // Update is called once per frame
     void Update()
     {

--- a/Assets/Scripts/SwordSwing.cs
+++ b/Assets/Scripts/SwordSwing.cs
@@ -45,6 +45,9 @@ public class SwordSwing : MonoBehaviour
     [SerializeField]
     private TrailRenderer trail = null;
 
+    [SerializeField]
+    private AttackTriggerCallback callback = null;
+
     void UpdatePosition() {
         Vector3 offset = new Vector2();
         offset.x = radius * Mathf.Cos((angle + cachedMouseAngle) * Mathf.Deg2Rad);
@@ -65,6 +68,7 @@ public class SwordSwing : MonoBehaviour
 
 
         if(Input.GetButton("Fire1") && !pressed) {
+            callback.EnableHitbox();
             swings = 0;
 
             // Swing will pivot from this point
@@ -103,6 +107,7 @@ public class SwordSwing : MonoBehaviour
         }
         else {
             trail.emitting = false;
+            callback.DisableHitbox();
         }
 
 


### PR DESCRIPTION
Fix DashTrail bug where the player has their dash trail showing only when the game starts.

Fix Phantom hitbox that would damage enemies after the player swung. This resulted in changes to AttackTriggerCallback so that you can customize what tag to ignore. (might change in future)